### PR TITLE
Day2 - Propose simplification of frame modifier

### DIFF
--- a/Day2/Day2/ContentView.swift
+++ b/Day2/Day2/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
                 model
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 200, height: 200)
+                    .frame(width: 200)
             } placeholder: {
                 ProgressView()
             }


### PR DESCRIPTION
Relates to #27

I would like to propose a small improvement to the teapot 3D model example. While reviewing the code, I noticed an opportunity to make it slightly more concise while maintaining the same functionality.

Current implementation:
```swift
.frame(width: 200, height: 200)
```

Proposed change:
```swift
.frame(width: 200)
```

Rationale:
- Since we're already using `aspectRatio(contentMode: .fit)`, the height will automatically adjust to maintain proper proportions
- This change would make the code a bit more concise while preserving the exact same visual result
- It follows SwiftUI's best practices of letting the framework handle automatic sizing when appropriate

I would greatly appreciate your thoughts on this suggestion. Please let me know if you would like me to make any adjustments to this proposal.

Thank you for considering this change!