### PR TITLE
Fix typo: occured→occurred in AppState.swift (Day39)

### DIFF
--- a/Day39/Day39/AppState.swift
+++ b/Day39/Day39/AppState.swift
@@ -48,7 +48,7 @@ class AppState {
             case .authorizationChanged(let type, let status):
                 print("Authorization type \(type) changed to \(status)")
             default:
-                print("An unknown event occured \(event)")
+                print("An unknown event occurred \(event)")
             }
         }
     }


### PR DESCRIPTION
## Summary
Fix typo in Day 39's AppState.swift: `occured` → `occurred`

**File:** `Day39/Day39/AppState.swift:51`
**Before:** `print("An unknown event occured \(event)")`
**After:** `print("An unknown event occurred \(event)")`

## Checklist
- [x] One commit only
- [x] No unrelated changes
- [x] CI passing